### PR TITLE
Generate unique slugs for identically named headers

### DIFF
--- a/src/bin/mdbook-toc.rs
+++ b/src/bin/mdbook-toc.rs
@@ -27,11 +27,9 @@ fn main() {
 
     if let Some(sub_args) = matches.subcommand_matches("supports") {
         handle_supports(sub_args);
-    } else {
-        if let Err(e) = handle_preprocessing() {
-            eprintln!("{}", e);
-            process::exit(1);
-        }
+    } else if let Err(e) = handle_preprocessing() {
+        eprintln!("{}", e);
+        process::exit(1);
     }
 }
 


### PR DESCRIPTION
mdBook creates unique slugs for headings by appending `-{n}`, where `n` is the number of times a heading with the same name has appeared before:

https://github.com/rust-lang/mdBook/blob/7af4b1dfe80903e3a2288355a2a396e7458866ee/src/renderer/html_handlebars/hbs_renderer.rs#L742-L764

This follows the same process to ensure the links match.
I also optimized string handling to reduce allocations (using `write!()` instead of `format!()` + `push()`/`push_str()`), and also applied clippy fixes.