### PR TITLE
Added minimum Rust version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MPL-2.0"
 homepage = "https://github.com/badboy/mdbook-toc"
 repository = "https://github.com/badboy/mdbook-toc"
 edition = "2018"
+rust-version = "1.58"
 
 [dependencies]
 mdbook = "0.4.10"


### PR DESCRIPTION
I was installing this crate to work on another project and realized I couldn't build this because I was using Rust `1.57` which doesn't yet have the fstrings. I am upgrading my local install to `1.60`, but prior to that I verified that everything seemed good to go on `1.58.1`.