### PR TITLE
Don't hardcode unix newlines in default marker

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@ use toml::value::Table;
 
 pub struct Toc;
 
-static DEFAULT_MARKER: &str = "<!-- toc -->\n";
+static DEFAULT_MARKER: &str = "<!-- toc -->";
 
 /// Configuration for Table of Contents generation
 pub struct Config {
-    /// Marker to use, defaults to `<!-- toc -->\n`
+    /// Marker to use, defaults to `<!-- toc -->`
     pub marker: String,
     /// The maximum level of headers to include in the table of contents.
     /// Defaults to `4`.


### PR DESCRIPTION
Not 100% sure if this is the ideal solution for you but I just spent like 2 hours being extremely confused and trying to debug mdbook-toc not working at all... because the default template is completely broken in the face of inputs with CRLFs in them (I'm on windows).

I can manually fix this in my own project by setting the marker to this in the config, but it's a nasty landmine for others that should probably get some kind of a fix..?