### PR TITLE
Set rust-version to correct MSRV of 1.66

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MPL-2.0"
 homepage = "https://github.com/badboy/mdbook-toc"
 repository = "https://github.com/badboy/mdbook-toc"
 edition = "2018"
-rust-version = "1.58"
+rust-version = "1.66"
 
 [dependencies]
 mdbook = "0.4.32"


### PR DESCRIPTION
As tested with `cargo-msrv`, the actual MSRV is 1.66 (due to the mdbook dependency), and not 1.58.
