### PR TITLE
Inline format arguments where possible

### DIFF
--- a/src/bin/mdbook-toc.rs
+++ b/src/bin/mdbook-toc.rs
@@ -28,7 +28,7 @@ fn main() {
     if let Some(sub_args) = matches.subcommand_matches("supports") {
         handle_supports(sub_args);
     } else if let Err(e) = handle_preprocessing() {
-        eprintln!("{}", e);
+        eprintln!("{e}");
         process::exit(1);
     }
 }


### PR DESCRIPTION
Already used in some places, there where several places left where the formatting arguments could be inlined. E.g. `format!("{value}")` instead of `format!("{}", value)`.
