### PR TITLE
Simplify CLI definition with derive macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,18 +218,20 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.12"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
+ "clap_derive",
+ "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.12"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -246,6 +248,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc443334c81a804575546c5a8a79b4913b50e28d69232903604cada1de817ce"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -674,6 +688,12 @@ checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.58"
 mdbook = "0.4.32"
 pulldown-cmark = "0.9.1"
 log = "0.4.11"
-clap = { version = "4.0.29", features = ["cargo"] }
+clap = { version = "4.3.19", features = ["cargo", "derive"] }
 serde_json = "1.0.57"
 toml = "0.7.6"
 

--- a/src/bin/mdbook-toc.rs
+++ b/src/bin/mdbook-toc.rs
@@ -3,7 +3,7 @@ extern crate mdbook;
 extern crate mdbook_toc;
 extern crate serde_json;
 
-use clap::{crate_version, Arg, ArgMatches, Command};
+use clap::{Parser, Subcommand};
 use mdbook::errors::Error;
 use mdbook::preprocess::{CmdPreprocessor, Preprocessor};
 use mdbook_toc::Toc;
@@ -11,22 +11,24 @@ use mdbook_toc::Toc;
 use std::io;
 use std::process;
 
-pub fn make_app() -> Command {
-    Command::new("mdbook-toc")
-        .version(crate_version!())
-        .about("mdbook preprocessor to add Table of Contents")
-        .subcommand(
-            Command::new("supports")
-                .arg(Arg::new("renderer").required(true))
-                .about("Check whether a renderer is supported by this preprocessor"),
-        )
+#[derive(Parser)]
+#[command(about, version)]
+struct App {
+    #[command(subcommand)]
+    cmd: Option<Cmd>,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Check whether a renderer is supported by this preprocessor
+    Supports { renderer: String },
 }
 
 fn main() {
-    let matches = make_app().get_matches();
+    let app = App::parse();
 
-    if let Some(sub_args) = matches.subcommand_matches("supports") {
-        handle_supports(sub_args);
+    if let Some(Cmd::Supports { renderer }) = app.cmd {
+        handle_supports(&renderer);
     } else if let Err(e) = handle_preprocessing() {
         eprintln!("{}", e);
         process::exit(1);
@@ -51,10 +53,7 @@ fn handle_preprocessing() -> Result<(), Error> {
     Ok(())
 }
 
-fn handle_supports(sub_args: &ArgMatches) -> ! {
-    let renderer = sub_args
-        .get_one::<String>("renderer")
-        .expect("Required argument");
+fn handle_supports(renderer: &str) -> ! {
     let supported = Toc.supports_renderer(renderer);
 
     // Signal whether the renderer is supported by exiting with 1 or 0.


### PR DESCRIPTION
Use clap's derive macro feature to simplify the definition and usage of the passed and valid CLI arguments.
