### PR TITLE
fix: Fix panic on headers with no text content

### DIFF
--- a/tests/header_with_only_attributes.in.md
+++ b/tests/header_with_only_attributes.in.md
@@ -1,0 +1,5 @@
+<!-- toc -->
+
+# {#custom-id}
+
+## Normal Header

--- a/tests/header_with_only_attributes.out.md
+++ b/tests/header_with_only_attributes.out.md
@@ -1,0 +1,5 @@
+* [Normal Header](#normal-header)
+
+# {#custom-id}
+
+## Normal Header

--- a/tests/it.rs
+++ b/tests/it.rs
@@ -191,3 +191,10 @@ fn escaped_brackets() {
 fn umlaute() {
     assert_toc!("umlaute");
 }
+
+#[test]
+fn header_with_only_attributes() {
+    // Regression test for headers containing only attributes (e.g., `# {#custom-id}`).
+    // These should be skipped in the TOC without causing a panic.
+    assert_toc!("header_with_only_attributes");
+}


### PR DESCRIPTION
  Fixes a panic when processing headers that contain only attributes (e.g., # {#custom-id}) or other non-text content.

  Problem:
  Headers with no Text or Code events would leave the span end at 0 while the start was a positive offset, causing a slice panic: begin <= end (16 <= 0) when slicing.

  This can happen when an include file contains <!-- toc --> and the document has headers with only custom ID attributes.

  Solution:
  - Track header span end as Option<usize> instead of usize
  - Skip headers where no text content was found

  Includes a regression test.

  ---